### PR TITLE
BLEN-119: Refactor code after viewport render implementation

### DIFF
--- a/extern/hdusd/CMakeLists.txt
+++ b/extern/hdusd/CMakeLists.txt
@@ -100,11 +100,13 @@ set(ADDON_UI_FILES
   addon/ui/material.py
   addon/ui/light.py
   addon/ui/panels.py
+  addon/ui/usd_nodes.py
 )
 
 set(ADDON_UTILS_FILES
   addon/utils/__init__.py
   addon/utils/stages.py
+  addon/utils/logging.py
 )
 
 set(HDUSD_INSTALL_PATH "scripts/addons/hdusd")

--- a/extern/hdusd/addon/engine.py
+++ b/extern/hdusd/addon/engine.py
@@ -42,7 +42,7 @@ class HdUSDEngine(bpy.types.RenderEngine):
     # final render
     def update(self, data, depsgraph):
         if not self.session:
-            self.session = _hdusd.create(self.as_pointer(), data.as_pointer())
+            self.session = _hdusd.create(self.as_pointer())
 
         _hdusd.reset(self.session, data.as_pointer(), depsgraph.as_pointer())
 
@@ -63,14 +63,19 @@ class HdUSDEngine(bpy.types.RenderEngine):
         if not output_node:
             return
 
-        stage_id = stages.get(output_node)
+        stage = stages.get(output_node)
+        if not stage:
+            return
 
         if not self.session:
-            self.session = _hdusd.create(self.as_pointer(), data.as_pointer(), stage_id)
+            self.session = _hdusd.create(self.as_pointer())
 
-        _hdusd.reset(self.session, data.as_pointer(), depsgraph.as_pointer())
+        _hdusd.reset(self.session, data.as_pointer(), depsgraph.as_pointer(), stage)
 
     def view_draw(self, context, depsgraph):
+        if not self.session:
+            return
+
         depsgraph_ptr = depsgraph.as_pointer()
         space_data_ptr = context.space_data.as_pointer()
         region_data_ptr = context.region_data.as_pointer()

--- a/extern/hdusd/addon/ui/__init__.py
+++ b/extern/hdusd/addon/ui/__init__.py
@@ -39,6 +39,7 @@ from . import (
     material,
     world,
     object,
+    usd_nodes,
 )
 
 
@@ -93,6 +94,11 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
 
     object.HDUSD_OBJECT_PT_usd_settings,
     object.HDUSD_OP_usd_object_show_hide,
+
+    usd_nodes.HDUSD_OP_usd_tree_node_print_stage,
+    usd_nodes.HDUSD_OP_usd_tree_node_print_root_layer,
+    usd_nodes.HDUSD_NODE_PT_usd_nodetree_tools,
+    usd_nodes.HDUSD_NODE_PT_usd_nodetree_dev,
 ])
 
 

--- a/extern/hdusd/addon/ui/usd_nodes.py
+++ b/extern/hdusd/addon/ui/usd_nodes.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2011-2022 Blender Foundation
+
+# <pep8 compliant>
+
+import _hdusd
+from . import HdUSD_Panel, HdUSD_ChildPanel, HdUSD_Operator
+
+from ..utils.logging import Log
+log = Log('ui.usd_nodes')
+
+
+class HDUSD_OP_usd_tree_node_print_stage(HdUSD_Operator):
+    """ Print selected USD nodetree node stage to console """
+    bl_idname = "hdusd.usd_tree_node_print_stage"
+    bl_label = "Print Stage To Console"
+
+    @classmethod
+    def poll(cls, context):
+        return super().poll(context) and context.space_data.tree_type == 'hdusd.USDTree' and \
+               context.active_node
+
+    def execute(self, context):
+        node = context.active_node
+
+        stage = node.stage
+        if not stage:
+            log.info(f"No USD stage for node {node.name}")
+            return {'CANCELLED'}
+
+        usd_str = _hdusd.stage_export_to_str(stage, True)
+        print(usd_str)
+
+        return {'FINISHED'}
+
+
+class HDUSD_OP_usd_tree_node_print_root_layer(HdUSD_Operator):
+    """ Print selected USD nodetree node stage to console """
+    bl_idname = "hdusd.usd_tree_node_print_root_layer"
+    bl_label = "Print Root Layer To Console"
+
+    @classmethod
+    def poll(cls, context):
+        return super().poll(context) and context.space_data.tree_type == 'hdusd.USDTree' and \
+               context.active_node
+
+    def execute(self, context):
+        node = context.active_node
+
+        stage = node.stage
+        if not stage:
+            log.info(f"No USD stage for node {node.name}")
+            return {'CANCELLED'}
+
+        usd_str = _hdusd.stage_export_to_str(stage, False)
+        print(usd_str)
+
+        return {'FINISHED'}
+
+
+class HDUSD_NODE_PT_usd_nodetree_tools(HdUSD_Panel):
+    bl_label = "USD Tools"
+    bl_space_type = "NODE_EDITOR"
+    bl_region_type = "UI"
+    bl_category = "Tool"
+
+    @classmethod
+    def poll(cls, context):
+        tree = context.space_data.edit_tree
+        return super().poll(context) and tree and tree.bl_idname == 'hdusd.USDTree'
+
+    def draw(self, context):
+        # layout = self.layout
+        pass
+
+
+class HDUSD_NODE_PT_usd_nodetree_dev(HdUSD_ChildPanel):
+    bl_label = "Dev"
+    bl_parent_id = 'HDUSD_NODE_PT_usd_nodetree_tools'
+    bl_space_type = "NODE_EDITOR"
+    bl_region_type = "UI"
+    bl_category = "Tool"
+
+    # @classmethod
+    # def poll(cls, context):
+    #     return config.show_dev_settings
+
+    def draw(self, context):
+        layout = self.layout
+
+        layout.operator(HDUSD_OP_usd_tree_node_print_stage.bl_idname)
+        layout.operator(HDUSD_OP_usd_tree_node_print_root_layer.bl_idname)

--- a/extern/hdusd/addon/usd_nodes/nodes/base_node.py
+++ b/extern/hdusd/addon/usd_nodes/nodes/base_node.py
@@ -53,7 +53,8 @@ class USDNode(bpy.types.Node):
         stages.set(self, stage)
 
     def draw_buttons(self, context, layout):
-        layout.label(text=f"Stage: {self.stage}")
+        # layout.label(text=f"Stage: {self.stage}")
+        pass
 
     # COMPUTE FUNCTION
     def c_compute(self, *args):

--- a/extern/hdusd/addon/usd_nodes/nodes/base_node.py
+++ b/extern/hdusd/addon/usd_nodes/nodes/base_node.py
@@ -44,8 +44,16 @@ class USDNode(bpy.types.Node):
         nodetree = self.id_data
         nodetree.no_update_call(init_)
 
+    @property
+    def stage(self):
+        return stages.get(self)
+
+    @stage.setter
+    def stage(self, stage):
+        stages.set(self, stage)
+
     def draw_buttons(self, context, layout):
-        layout.label(text=f"Stage: {stages.get(self)}")
+        layout.label(text=f"Stage: {self.stage}")
 
     # COMPUTE FUNCTION
     def c_compute(self, *args):
@@ -63,18 +71,15 @@ class USDNode(bpy.types.Node):
         This is the entry point of node parser system.
         This function does some useful preparation before and after calling compute() function.
         """
-        stage = stages.get(self)
-        if not stage:
+        if not self.stage:
             # log("compute", self, group_nodes)
-            stage = self.compute(group_nodes=group_nodes, **kwargs)
-            if stage:
-                stages.set(self, stage)
+            self.stage = self.compute(group_nodes=group_nodes, **kwargs)
 
             #self.hdusd.usd_list.update_items()
             self.node_computed()
 
-        print("final_compute stage:", stage, self.name)
-        return stage if stage else None
+        print("final_compute stage:", self.stage, self.name)
+        return self.stage
 
     def _compute_node(self, node, group_node=None, **kwargs):
         """

--- a/extern/hdusd/addon/utils/logging.py
+++ b/extern/hdusd/addon/utils/logging.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2011-2022 Blender Foundation
+
+# <pep8 compliant>
+
+import sys
+import logging.handlers
+
+# from . import PLUGIN_ROOT_DIR
+# from .. import config
+
+
+FORMAT_STR = "%(asctime)s %(levelname)s %(name)s [%(thread)d]:  %(message)s"
+
+# root logger for the addon
+logger = logging.getLogger('hdusd')
+# logger.setLevel(config.logging_level)
+logger.setLevel('DEBUG')
+
+# file_handler = logging.handlers.RotatingFileHandler(PLUGIN_ROOT_DIR / 'hdusd.log',
+#                                                     mode='w', encoding='utf-8', delay=True,
+#                                                     backupCount=config.logging_backups)
+# file_handler.doRollover()
+# file_handler.setFormatter(logging.Formatter(FORMAT_STR))
+# logger.addHandler(file_handler)
+
+console_handler = logging.StreamHandler(stream=sys.stdout)
+console_handler.setFormatter(logging.Formatter(FORMAT_STR))
+logger.addHandler(console_handler)
+
+
+def msg(args):
+    return ", ".join(str(arg) for arg in args)
+
+
+class Log:
+    def __init__(self, tag):
+        self.logger = logger.getChild(tag)
+
+    def __call__(self, *args):
+        self.debug(*args)
+
+    def debug(self, *args):
+        self.logger.debug(msg(args))
+
+    def info(self, *args):
+        self.logger.info(msg(args))
+
+    def warn(self, *args):
+        self.logger.warning(msg(args))
+
+    def error(self, *args):
+        self.logger.error(msg(args))
+
+    def critical(self, *args):
+        self.logger.critical(msg(args))
+
+    def dump_args(self, func):
+        """This decorator dumps out the arguments passed to a function before calling it"""
+        arg_names = func.__code__.co_varnames[:func.__code__.co_argcount]
+
+        def echo_func(*args, **kwargs):
+            self.debug("<{}>: {}{}".format(
+                func.__name__,
+                tuple("{}={}".format(name, arg) for name, arg in zip(arg_names, args)),
+                # args if args else "",
+                " {}".format(kwargs.items()) if kwargs else "",
+            ))
+            return func(*args, **kwargs)
+
+        return echo_func

--- a/extern/hdusd/addon/utils/stages.py
+++ b/extern/hdusd/addon/utils/stages.py
@@ -14,12 +14,13 @@ def key(bl_obj):
 
 
 def get(bl_obj):
-    return _stages.get(key(bl_obj), 0)
+    return _stages.get(key(bl_obj), None)
 
 
 def set(bl_obj, stage):
     free(bl_obj)
-    _stages[key(bl_obj)] = stage
+    if stage:
+        _stages[key(bl_obj)] = stage
 
 
 def free(bl_obj):

--- a/extern/hdusd/camera.cpp
+++ b/extern/hdusd/camera.cpp
@@ -4,6 +4,8 @@
 #include "camera.h"
 #include "utils.h"
 
+namespace hdusd {
+
 CameraData::CameraData() {
 }
 
@@ -115,3 +117,5 @@ pxr::GfCamera CameraData::export_gf(vector<float> tile)
   
   return gf_camera;
 }
+
+} //namespace hdusd

--- a/extern/hdusd/camera.h
+++ b/extern/hdusd/camera.h
@@ -10,6 +10,8 @@
 
 using namespace std;
 
+namespace hdusd {
+
 class CameraData {
   public:
     CameraData();
@@ -31,3 +33,5 @@ class CameraData {
     vector<float> ortho_size;
     tuple<float, float, int> dof_size;
 };
+
+} // namespace hdusd

--- a/extern/hdusd/python.cpp
+++ b/extern/hdusd/python.cpp
@@ -27,6 +27,7 @@ namespace hdusd {
 
 static PyObject *init_func(PyObject * /*self*/, PyObject *args)
 {
+  DLOG(INFO) << "init_func";
   blender::io::usd::ensure_usd_plugin_path_registered();
   stageCache = std::make_unique<pxr::UsdStageCache>();
 
@@ -35,15 +36,16 @@ static PyObject *init_func(PyObject * /*self*/, PyObject *args)
 
 static PyObject *exit_func(PyObject * /*self*/, PyObject * /*args*/)
 {
+  DLOG(INFO) << "exit_func";
   stageCache = nullptr;
   Py_RETURN_NONE;
 }
 
 static PyObject *create_func(PyObject * /*self*/, PyObject *args)
 {
-  PyObject *pyengine, *pydata;
-  int stageId = -1;
-  if (!PyArg_ParseTuple(args, "OOi", &pyengine, &pydata, &stageId)) {
+  DLOG(INFO) << "create_func";
+  PyObject *pyengine;
+  if (!PyArg_ParseTuple(args, "O", &pyengine)) {
     Py_RETURN_NONE;
   }
 
@@ -51,38 +53,31 @@ static PyObject *create_func(PyObject * /*self*/, PyObject *args)
   RNA_pointer_create(NULL, &RNA_RenderEngine, (void *)PyLong_AsVoidPtr(pyengine), &engineptr);
   BL::RenderEngine engine(engineptr);
 
-  PointerRNA dataptr;
-  RNA_main_pointer_create((Main *)PyLong_AsVoidPtr(pydata), &dataptr);
-  BL::BlendData data(dataptr);
-
   /* create session */
-  BlenderSession *session = new BlenderSession(engine, data);
-
-  pxr::TfToken plugin = pxr::TfToken("HdStormRendererPlugin");
-
-  if (!session->imagingGLEngine->SetRendererPlugin(plugin)) {
-    Py_RETURN_NONE;
-  }
-
-  session->stage = stageCache->Find(pxr::UsdStageCache::Id::FromLongInt(stageId));
-
-  session->imagingGLEngine->SetRendererAov(pxr::HdAovTokens->color);
-
+  BlenderSession *session = new BlenderSession(engine);
   return PyLong_FromVoidPtr(session);
 }
 
-static PyObject *free_func(PyObject * /*self*/, PyObject *value)
+static PyObject *free_func(PyObject * /*self*/, PyObject *args)
 {
-  delete (BlenderSession *)PyLong_AsVoidPtr(value);
+  DLOG(INFO) << "free_func";
+  PyObject *pysession;
+  if (!PyArg_ParseTuple(args, "O", &pysession)) {
+    Py_RETURN_NONE;
+  }
+
+  delete (BlenderSession *)PyLong_AsVoidPtr(pysession);
   Py_RETURN_NONE;
 }
 
 static PyObject *render_func(PyObject * /*self*/, PyObject *args)
 {
+  DLOG(INFO) << "render_func";
   PyObject *pysession, *pydepsgraph;
 
-  if (!PyArg_ParseTuple(args, "OO", &pysession, &pydepsgraph))
-    return NULL;
+  if (!PyArg_ParseTuple(args, "OO", &pysession, &pydepsgraph)) {
+    Py_RETURN_NONE;
+  }
 
   BlenderSession *session = (BlenderSession *)PyLong_AsVoidPtr(pysession);
 
@@ -102,10 +97,12 @@ static PyObject *render_func(PyObject * /*self*/, PyObject *args)
 
 static PyObject *reset_func(PyObject * /*self*/, PyObject *args)
 {
+  DLOG(INFO) << "reset_func";
   PyObject *pysession, *pydata, *pydepsgraph;
-
-  if (!PyArg_ParseTuple(args, "OOO", &pysession, &pydata, &pydepsgraph))
-    return NULL;
+  int stageId = 0;
+  if (!PyArg_ParseTuple(args, "OOOi", &pysession, &pydata, &pydepsgraph, &stageId)) {
+    Py_RETURN_NONE;
+  }
 
   BlenderSession *session = (BlenderSession *)PyLong_AsVoidPtr(pysession);
 
@@ -117,13 +114,13 @@ static PyObject *reset_func(PyObject * /*self*/, PyObject *args)
   RNA_pointer_create(NULL, &RNA_Depsgraph, (ID *)PyLong_AsVoidPtr(pydepsgraph), &depsgraphptr);
   BL::Depsgraph depsgraph(depsgraphptr);
 
-  ///* Allow Blender to execute other Python scripts. */
-  //python_thread_state_save(&session->python_thread_state);
+  pxr::TfToken plugin = pxr::TfToken("HdStormRendererPlugin");
+  if (!session->imagingGLEngine->SetRendererPlugin(plugin)) {
+    Py_RETURN_NONE;
+  }
 
-  //session->render(b_depsgraph);
-
-  //python_thread_state_restore(&session->python_thread_state);
-
+  session->stage = stageCache->Find(pxr::UsdStageCache::Id::FromLongInt(stageId));
+  session->imagingGLEngine->SetRendererAov(pxr::HdAovTokens->color);
   Py_RETURN_NONE;
 }
 
@@ -134,15 +131,19 @@ static PyObject *render_frame_finish_func(PyObject * /*self*/, PyObject *args)
 
 static PyObject *view_update_func(PyObject * /*self*/, PyObject *args)
 {
+  DLOG(INFO) << "view_update_func";
   Py_RETURN_NONE;
 }
 
 static PyObject *view_draw_func(PyObject * /*self*/, PyObject *args)
 {
+  DLOG(INFO) << "view_draw_func";
+
   PyObject *pysession, *pydepsgraph, *pycontext, *pyspaceData, *pyregionData;
 
-  if (!PyArg_ParseTuple(args, "OOOOO", &pysession, &pydepsgraph, &pycontext, &pyspaceData, &pyregionData))
-    return NULL;
+  if (!PyArg_ParseTuple(args, "OOOOO", &pysession, &pydepsgraph, &pycontext, &pyspaceData, &pyregionData)) {
+    Py_RETURN_NONE;
+  }
 
   BlenderSession *session = (BlenderSession *)PyLong_AsVoidPtr(pysession);
 
@@ -181,6 +182,14 @@ static PyObject *view_draw_func(PyObject * /*self*/, PyObject *args)
   session->imagingGLEngine->Render(session->stage->GetPseudoRoot(), session->render_params);
 
   b_engine.unbind_display_space_shader();
+
+  
+  ///* Allow Blender to execute other Python scripts. */
+  //python_thread_state_save(&session->python_thread_state);
+
+  //session->render(b_depsgraph);
+
+  //python_thread_state_restore(&session->python_thread_state);
 
   Py_RETURN_NONE;
 }

--- a/extern/hdusd/session.cpp
+++ b/extern/hdusd/session.cpp
@@ -7,9 +7,8 @@ namespace hdusd {
 
 std::unique_ptr<pxr::UsdStageCache> stageCache;
 
-BlenderSession::BlenderSession(BL::RenderEngine &b_engine, BL::BlendData &b_data)
+BlenderSession::BlenderSession(BL::RenderEngine &b_engine)
     : b_engine(b_engine)
-    , b_data(b_data)
 {
   imagingGLEngine = std::make_unique<pxr::UsdImagingGLEngine>();
 }

--- a/extern/hdusd/session.cpp
+++ b/extern/hdusd/session.cpp
@@ -6,12 +6,12 @@
 namespace hdusd {
 
 std::unique_ptr<pxr::UsdStageCache> stageCache;
-std::unique_ptr<pxr::UsdImagingGLEngine> imagingGLEngine;
 
 BlenderSession::BlenderSession(BL::RenderEngine &b_engine, BL::BlendData &b_data)
     : b_engine(b_engine)
     , b_data(b_data)
 {
+  imagingGLEngine = std::make_unique<pxr::UsdImagingGLEngine>();
 }
 
 BlenderSession::~BlenderSession()

--- a/extern/hdusd/session.h
+++ b/extern/hdusd/session.h
@@ -15,7 +15,6 @@
 namespace hdusd {
 
 extern std::unique_ptr<pxr::UsdStageCache> stageCache;
-extern std::unique_ptr<pxr::UsdImagingGLEngine> imagingGLEngine;
 
 class BlenderSession {
 public:
@@ -24,6 +23,10 @@ public:
 
   BL::RenderEngine b_engine;
   BL::BlendData b_data;
+
+  std::unique_ptr<pxr::UsdImagingGLEngine> imagingGLEngine;
+  pxr::UsdImagingGLRenderParams render_params;
+  pxr::UsdStageRefPtr stage;
 };
 
 }   // namespace hdusd

--- a/extern/hdusd/session.h
+++ b/extern/hdusd/session.h
@@ -18,11 +18,11 @@ extern std::unique_ptr<pxr::UsdStageCache> stageCache;
 
 class BlenderSession {
 public:
-  BlenderSession(BL::RenderEngine &b_engine, BL::BlendData &b_data);
+  BlenderSession(BL::RenderEngine &b_engine);
   ~BlenderSession();
 
   BL::RenderEngine b_engine;
-  BL::BlendData b_data;
+  //BL::BlendData b_data;
 
   std::unique_ptr<pxr::UsdImagingGLEngine> imagingGLEngine;
   pxr::UsdImagingGLRenderParams render_params;

--- a/extern/hdusd/usdImagingLite/engine.cpp
+++ b/extern/hdusd/usdImagingLite/engine.cpp
@@ -22,6 +22,8 @@
 #include "engine.h"
 #include "renderDataDelegate.h"
 
+namespace hdusd {
+
 UsdImagingLiteEngine::UsdImagingLiteEngine()
     : _isPopulated(false)
 {
@@ -305,3 +307,5 @@ VtDictionary UsdImagingLiteEngine::GetRenderStats() const
 {
     return _renderDelegate->GetRenderStats();
 }
+
+} // namespace hdusd

--- a/extern/hdusd/usdImagingLite/engine.h
+++ b/extern/hdusd/usdImagingLite/engine.h
@@ -15,6 +15,8 @@
 #include "renderDataDelegate.h"
 #include "renderTask.h"
 
+namespace hdusd {
+
 /// \class UsdImagingLiteEngine
 ///
 /// The UsdImagingLiteEngine is entry point API for rendering USD scenes for delegates
@@ -161,3 +163,5 @@ private:
 
     SdfPath _GetRendererAovPath(TfToken const &aov) const;
 };
+
+} // namespace hdusd

--- a/extern/hdusd/usdImagingLite/renderDataDelegate.cpp
+++ b/extern/hdusd/usdImagingLite/renderDataDelegate.cpp
@@ -3,6 +3,8 @@
 
 #include "renderDataDelegate.h"
 
+namespace hdusd {
+
 HdRenderDataDelegate::HdRenderDataDelegate(HdRenderIndex* parentIndex, SdfPath const& delegateID)
     : HdSceneDelegate(parentIndex, delegateID)
 {}
@@ -61,3 +63,5 @@ TfTokenVector HdRenderDataDelegate::GetTaskRenderTags(SdfPath const& taskId)
     }
     return TfTokenVector();
 }
+
+} // namespace hdusd

--- a/extern/hdusd/usdImagingLite/renderDataDelegate.h
+++ b/extern/hdusd/usdImagingLite/renderDataDelegate.h
@@ -11,6 +11,8 @@
 
 using namespace pxr;
 
+namespace hdusd {
+
 TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (renderBufferDescriptor)
     (renderTags));
@@ -50,3 +52,5 @@ private:
     typedef TfHashMap<SdfPath, ValueCache, SdfPath::Hash> ValueCacheMap;
     ValueCacheMap _valueCacheMap;
 };
+
+} // namespace hdusd

--- a/extern/hdusd/usdImagingLite/renderParams.h
+++ b/extern/hdusd/usdImagingLite/renderParams.h
@@ -13,6 +13,8 @@
 
 using namespace pxr;
 
+namespace hdusd {
+
 /// \class UsdImagingLiteRenderParams
 ///
 /// Used as an arguments class for various methods in UsdImagingLiteEngine.
@@ -60,3 +62,5 @@ bool UsdImagingLiteRenderParams::operator==(const UsdImagingLiteRenderParams &ot
         && aovs == other.aovs
         && aovBuffers == other.aovBuffers;
 }
+
+} // namespace hdusd

--- a/extern/hdusd/usdImagingLite/renderTask.cpp
+++ b/extern/hdusd/usdImagingLite/renderTask.cpp
@@ -8,6 +8,8 @@
 
 #include "renderTask.h"
 
+namespace hdusd {
+
 HdRenderTask::HdRenderTask(HdSceneDelegate* delegate, SdfPath const& id)
     : HdTask(id)
 {
@@ -146,3 +148,5 @@ bool operator!=(const HdRenderTaskParams& lhs, const HdRenderTaskParams& rhs)
 {
     return !(lhs == rhs);
 }
+
+} // namespace hdusd

--- a/extern/hdusd/usdImagingLite/renderTask.h
+++ b/extern/hdusd/usdImagingLite/renderTask.h
@@ -9,6 +9,8 @@
 
 using namespace pxr;
 
+namespace hdusd {
+
 class HdRenderTask : public HdTask
 {
 public:
@@ -60,3 +62,5 @@ struct HdRenderTaskParams
 std::ostream& operator<<(std::ostream& out, const HdRenderTaskParams& pv);
 bool operator==(const HdRenderTaskParams& lhs, const HdRenderTaskParams& rhs);
 bool operator!=(const HdRenderTaskParams& lhs, const HdRenderTaskParams& rhs);
+
+} // namespace hdusd

--- a/extern/hdusd/utils.cpp
+++ b/extern/hdusd/utils.cpp
@@ -3,6 +3,8 @@
 
 #include "utils.h"
 
+namespace hdusd {
+
 string hdusd::get_random_string(const int len)
 {
   static const char alphanum[] =
@@ -205,3 +207,5 @@ BL::Array<float, 16> hdusd::matrix::convert_vector_to_array_4x4(vector<vector<fl
   }
   return arr;
 }
+
+} // namespace hdusd

--- a/extern/hdusd/view_settings.cpp
+++ b/extern/hdusd/view_settings.cpp
@@ -5,6 +5,8 @@
 
 using namespace std;
 
+namespace hdusd {
+
 ViewSettings::ViewSettings(BL::Context b_context)
 {
   this->camera_data = CameraData::init_from_context(b_context);
@@ -59,3 +61,5 @@ pxr::GfCamera ViewSettings::export_camera()
             (float)border[1][0] / screen_width, (float)border[1][1] / screen_height}
          );
 }
+
+} // namespace hdusd

--- a/extern/hdusd/view_settings.h
+++ b/extern/hdusd/view_settings.h
@@ -8,6 +8,8 @@
 #include "MEM_guardedalloc.h"
 #include "RNA_blender_cpp.h"
 
+namespace hdusd {
+
 class ViewSettings {
   public:
     ViewSettings(BL::Context b_context);
@@ -25,3 +27,5 @@ class ViewSettings {
     int screen_height;
     vector<vector<int>> border;
 };
+
+} // namespace hdusd


### PR DESCRIPTION
Added hdusd namespace.
Moved imagingGLEngine, stage to BlenderSession class.
Fixed crash in viewport if no USD stage is available.
Added logging to python code: utils/logging.py.
Added developer operators for viewing stage in USD node.