### PR TITLE
BLEN-146: Add MaterialX python bindings to Blender

### DIFF
--- a/build_files/build_environment/cmake/python_site_packages.cmake
+++ b/build_files/build_environment/cmake/python_site_packages.cmake
@@ -27,20 +27,6 @@ if(USE_PIP_NUMPY)
   )
 endif()
 
-if(WITH_USD)
-  if (BUILD_MODE STREQUAL Debug)
-    ExternalProject_Add_Step(external_python_site_packages after_install
-      COMMAND ${PYTHON_BINARY} -m pip install --no-cache-dir ${LIBDIR}/MaterialX/python/MaterialX-1.38.0_d.tar.gz
-      DEPENDEES install
-    )
-  else()
-    ExternalProject_Add_Step(external_python_site_packages after_install
-      COMMAND ${PYTHON_BINARY} -m pip install --no-cache-dir ${LIBDIR}/MaterialX/python/MaterialX-1.38.0_r.tar.gz
-      DEPENDEES install
-    )
-  endif()
-endif()
-
 add_dependencies(
   external_python_site_packages
   external_python

--- a/build_files/build_environment/cmake/python_site_packages.cmake
+++ b/build_files/build_environment/cmake/python_site_packages.cmake
@@ -35,7 +35,7 @@ if(WIN32 AND WITH_USD)
     )
   else()
     ExternalProject_Add_Step(external_python_site_packages after_install
-      COMMAND ${PYTHON_BINARY} -m pip install --no-cache-dir ${LIBDIR}/MaterialX/python/MaterialX-1.38.0.tar.gz
+      COMMAND ${PYTHON_BINARY} -m pip install --no-cache-dir ${LIBDIR}/MaterialX/python/MaterialX-1.38.0_r.tar.gz
       DEPENDEES install
     )
   endif()

--- a/build_files/build_environment/cmake/python_site_packages.cmake
+++ b/build_files/build_environment/cmake/python_site_packages.cmake
@@ -27,7 +27,7 @@ if(USE_PIP_NUMPY)
   )
 endif()
 
-if(WIN32 AND WITH_USD)
+if(WITH_USD)
   if (BUILD_MODE STREQUAL Debug)
     ExternalProject_Add_Step(external_python_site_packages after_install
       COMMAND ${PYTHON_BINARY} -m pip install --no-cache-dir ${LIBDIR}/MaterialX/python/MaterialX-1.38.0_d.tar.gz

--- a/build_files/build_environment/cmake/python_site_packages.cmake
+++ b/build_files/build_environment/cmake/python_site_packages.cmake
@@ -27,6 +27,20 @@ if(USE_PIP_NUMPY)
   )
 endif()
 
+if(WIN32 AND WITH_USD)
+  if (BUILD_MODE STREQUAL Debug)
+    ExternalProject_Add_Step(external_python_site_packages after_install
+      COMMAND ${PYTHON_BINARY} -m pip install --no-cache-dir ${LIBDIR}/MaterialX/python/MaterialX-1.38.0_d.tar.gz
+      DEPENDEES install
+    )
+  else()
+    ExternalProject_Add_Step(external_python_site_packages after_install
+      COMMAND ${PYTHON_BINARY} -m pip install --no-cache-dir ${LIBDIR}/MaterialX/python/MaterialX-1.38.0.tar.gz
+      DEPENDEES install
+    )
+  endif()
+endif()
+
 add_dependencies(
   external_python_site_packages
   external_python

--- a/source/creator/CMakeLists.txt
+++ b/source/creator/CMakeLists.txt
@@ -865,6 +865,27 @@ elseif(WIN32)
         CONFIGURATIONS Debug
       )
 
+      if(WITH_USD)
+        install(
+          DIRECTORY ${LIBDIR}/MaterialX/python/debug/site-packages
+          DESTINATION ${TARGETDIR_VER}/python/lib
+          CONFIGURATIONS Debug
+          PATTERN ".svn" EXCLUDE
+          PATTERN "__pycache__" EXCLUDE           # * any cache *
+          PATTERN "*.pyc" EXCLUDE                 # * any cache *
+          PATTERN "*.pyo" EXCLUDE                 # * any cache *
+        )
+        install(
+          DIRECTORY ${LIBDIR}/MaterialX/python/release/site-packages
+          DESTINATION ${TARGETDIR_VER}/python/lib
+          CONFIGURATIONS Release;RelWithDebInfo;MinSizeRel
+          PATTERN ".svn" EXCLUDE
+          PATTERN "__pycache__" EXCLUDE           # * any cache *
+          PATTERN "*.pyc" EXCLUDE                 # * any cache *
+          PATTERN "*.pyo" EXCLUDE                 # * any cache *
+        )
+      endif()
+
       if(WINDOWS_PYTHON_DEBUG)
         install(
           FILES ${LIBDIR}/python/${_PYTHON_VERSION_NO_DOTS}/libs/python${_PYTHON_VERSION_NO_DOTS}.pdb


### PR DESCRIPTION
- Added MaterialX packages for python;
- updated blender build script.

See Jira ticket for instruction on how to get MaterialX packages.