### PR TITLE
BLEN-166: Fix differences of light power between renderers

### DIFF
--- a/source/blender/io/usd/intern/usd_writer_light.cc
+++ b/source/blender/io/usd/intern/usd_writer_light.cc
@@ -3,10 +3,12 @@
 #include "usd_writer_light.h"
 #include "usd_hierarchy_iterator.h"
 
+#include <pxr/base/gf/math.h>
 #include <pxr/usd/usdLux/diskLight.h>
 #include <pxr/usd/usdLux/distantLight.h>
 #include <pxr/usd/usdLux/rectLight.h>
 #include <pxr/usd/usdLux/sphereLight.h>
+#include <pxr/usd/usdLux/shapingAPI.h>
 
 #include "BLI_assert.h"
 #include "BLI_utildefines.h"
@@ -23,7 +25,7 @@ USDLightWriter::USDLightWriter(const USDExporterContext &ctx) : USDAbstractWrite
 bool USDLightWriter::is_supported(const HierarchyContext *context) const
 {
   Light *light = static_cast<Light *>(context->object->data);
-  return ELEM(light->type, LA_AREA, LA_LOCAL, LA_SUN);
+  return ELEM(light->type, LA_AREA, LA_LOCAL, LA_SUN, LA_SPOT);
 }
 
 void USDLightWriter::do_write(HierarchyContext &context)
@@ -40,13 +42,33 @@ void USDLightWriter::do_write(HierarchyContext &context)
 
 #endif
 
+   /* Scale factor to get to somewhat-similar illumination. Since the USDViewer had similar
+   * over-exposure as Blender Internal with the same values, this code applies the reverse of the
+   * versioning code in light_emission_unify(). */
+  float usd_intensity = light->energy;
+
   switch (light->type) {
     case LA_AREA:
       switch (light->area_shape) {
-        case LA_AREA_DISK:
+        case LA_AREA_DISK: {
+          pxr::UsdLuxDiskLight disk_light = pxr::UsdLuxDiskLight::Define(stage, usd_path);
+          disk_light.CreateRadiusAttr().Set(light->area_size / 2, timecode);
+
+          usd_intensity *= 30.0f;
+
+#if PXR_VERSION >= 2111
+          usd_light_api = disk_light.LightAPI();
+#else
+          usd_light_api = disk_light;
+#endif
+          break;
+        }
         case LA_AREA_ELLIPSE: { /* An ellipse light will deteriorate into a disk light. */
           pxr::UsdLuxDiskLight disk_light = pxr::UsdLuxDiskLight::Define(stage, usd_path);
-          disk_light.CreateRadiusAttr().Set(light->area_size, timecode);
+          disk_light.CreateRadiusAttr().Set((light->area_size + light->area_sizey) / 4, timecode);
+
+          usd_intensity *= 30.0f;
+
 #if PXR_VERSION >= 2111
           usd_light_api = disk_light.LightAPI();
 #else
@@ -58,6 +80,9 @@ void USDLightWriter::do_write(HierarchyContext &context)
           pxr::UsdLuxRectLight rect_light = pxr::UsdLuxRectLight::Define(stage, usd_path);
           rect_light.CreateWidthAttr().Set(light->area_size, timecode);
           rect_light.CreateHeightAttr().Set(light->area_sizey, timecode);
+
+          usd_intensity *= 30.0f;
+
 #if PXR_VERSION >= 2111
           usd_light_api = rect_light.LightAPI();
 #else
@@ -69,6 +94,9 @@ void USDLightWriter::do_write(HierarchyContext &context)
           pxr::UsdLuxRectLight rect_light = pxr::UsdLuxRectLight::Define(stage, usd_path);
           rect_light.CreateWidthAttr().Set(light->area_size, timecode);
           rect_light.CreateHeightAttr().Set(light->area_size, timecode);
+
+          usd_intensity *= 30.0f;
+
 #if PXR_VERSION >= 2111
           usd_light_api = rect_light.LightAPI();
 #else
@@ -81,6 +109,9 @@ void USDLightWriter::do_write(HierarchyContext &context)
     case LA_LOCAL: {
       pxr::UsdLuxSphereLight sphere_light = pxr::UsdLuxSphereLight::Define(stage, usd_path);
       sphere_light.CreateRadiusAttr().Set(light->area_size, timecode);
+
+      usd_intensity *= 2.5f;
+
 #if PXR_VERSION >= 2111
       usd_light_api = sphere_light.LightAPI();
 #else
@@ -90,7 +121,10 @@ void USDLightWriter::do_write(HierarchyContext &context)
     }
     case LA_SUN: {
       pxr::UsdLuxDistantLight distant_light = pxr::UsdLuxDistantLight::Define(stage, usd_path);
-      /* TODO(makowalski): set angle attribute here. */
+      distant_light.CreateAngleAttr().Set((float)pxr::GfRadiansToDegrees(light->sun_angle), timecode);
+
+      usd_intensity *= 35.0f;
+
 #if PXR_VERSION >= 2111
       usd_light_api = distant_light.LightAPI();
 #else
@@ -98,21 +132,31 @@ void USDLightWriter::do_write(HierarchyContext &context)
 #endif
       break;
     }
+    case LA_SPOT: {
+      pxr::UsdLuxSphereLight spot_light = pxr::UsdLuxSphereLight::Define(stage, usd_path);
+      pxr::UsdPrim spot_prim = stage->GetPrimAtPath(usd_path);
+
+      spot_light.CreateTreatAsPointAttr(pxr::VtValue(true));
+
+      float spot_size = (float)pxr::GfRadiansToDegrees(light->spotsize);
+
+      pxr::UsdLuxShapingAPI usd_shaping_api = pxr::UsdLuxShapingAPI(spot_prim);
+      usd_shaping_api.CreateShapingConeAngleAttr(pxr::VtValue(spot_size / 2));
+      usd_shaping_api.CreateShapingConeSoftnessAttr(pxr::VtValue(light->spotblend));
+
+      usd_intensity /= 10.0f;
+
+#if PXR_VERSION >= 2111
+          usd_light_api = spot_light.LightAPI();
+#else
+          usd_light_api = spot_light;
+#endif
+      break;
+    }
     default:
       BLI_assert_msg(0, "is_supported() returned true for unsupported light type");
   }
 
-  /* Scale factor to get to somewhat-similar illumination. Since the USDViewer had similar
-   * over-exposure as Blender Internal with the same values, this code applies the reverse of the
-   * versioning code in light_emission_unify(). */
-  float usd_intensity;
-  if (light->type == LA_SUN) {
-    /* Untested, as the Hydra GL viewport of USDViewer doesn't support distant lights. */
-    usd_intensity = light->energy;
-  }
-  else {
-    usd_intensity = light->energy / 100.0f;
-  }
   usd_light_api.CreateIntensityAttr().Set(usd_intensity, timecode);
 
   usd_light_api.CreateColorAttr().Set(pxr::GfVec3f(light->r, light->g, light->b), timecode);

--- a/source/blender/io/usd/intern/usd_writer_light.cc
+++ b/source/blender/io/usd/intern/usd_writer_light.cc
@@ -50,6 +50,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
           pxr::UsdLuxDiskLight disk_light = pxr::UsdLuxDiskLight::Define(stage, usd_path);
           disk_light.CreateRadiusAttr().Set(light->area_size / 2, timecode);
 
+          // Coefficient approximated to follow Cycles results
           usd_intensity *= 30.0f;
 
 #if PXR_VERSION >= 2111
@@ -63,6 +64,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
           pxr::UsdLuxDiskLight disk_light = pxr::UsdLuxDiskLight::Define(stage, usd_path);
           disk_light.CreateRadiusAttr().Set((light->area_size + light->area_sizey) / 4, timecode);
 
+          // Coefficient approximated to follow Cycles results
           usd_intensity *= 30.0f;
 
 #if PXR_VERSION >= 2111
@@ -77,6 +79,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
           rect_light.CreateWidthAttr().Set(light->area_size, timecode);
           rect_light.CreateHeightAttr().Set(light->area_sizey, timecode);
 
+          // Coefficient approximated to follow Cycles results
           usd_intensity *= 30.0f;
 
 #if PXR_VERSION >= 2111
@@ -91,6 +94,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
           rect_light.CreateWidthAttr().Set(light->area_size, timecode);
           rect_light.CreateHeightAttr().Set(light->area_size, timecode);
 
+          // Coefficient approximated to follow Cycles results
           usd_intensity *= 30.0f;
 
 #if PXR_VERSION >= 2111
@@ -106,6 +110,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
       pxr::UsdLuxSphereLight sphere_light = pxr::UsdLuxSphereLight::Define(stage, usd_path);
       sphere_light.CreateRadiusAttr().Set(light->area_size, timecode);
 
+      // Coefficient approximated to follow Cycles results
       usd_intensity *= 2.5f;
 
 #if PXR_VERSION >= 2111
@@ -119,6 +124,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
       pxr::UsdLuxDistantLight distant_light = pxr::UsdLuxDistantLight::Define(stage, usd_path);
       distant_light.CreateAngleAttr().Set((float)pxr::GfRadiansToDegrees(light->sun_angle), timecode);
 
+      // Coefficient approximated to follow Cycles results
       usd_intensity *= 35.0f;
 
 #if PXR_VERSION >= 2111
@@ -140,6 +146,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
       usd_shaping_api.CreateShapingConeAngleAttr(pxr::VtValue(spot_size / 2));
       usd_shaping_api.CreateShapingConeSoftnessAttr(pxr::VtValue(light->spotblend));
 
+      // Coefficient approximated to follow Cycles results
       usd_intensity /= 10.0f;
 
 #if PXR_VERSION >= 2111

--- a/source/blender/io/usd/intern/usd_writer_light.cc
+++ b/source/blender/io/usd/intern/usd_writer_light.cc
@@ -39,12 +39,8 @@ void USDLightWriter::do_write(HierarchyContext &context)
   pxr::UsdLuxLightAPI usd_light_api;
 #else
   pxr::UsdLuxLight usd_light_api;
-
 #endif
 
-   /* Scale factor to get to somewhat-similar illumination. Since the USDViewer had similar
-   * over-exposure as Blender Internal with the same values, this code applies the reverse of the
-   * versioning code in light_emission_unify(). */
   float usd_intensity = light->energy;
 
   switch (light->type) {

--- a/source/blender/io/usd/intern/usd_writer_light.cc
+++ b/source/blender/io/usd/intern/usd_writer_light.cc
@@ -48,7 +48,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
       switch (light->area_shape) {
         case LA_AREA_DISK: {
           pxr::UsdLuxDiskLight disk_light = pxr::UsdLuxDiskLight::Define(stage, usd_path);
-          // light.size is diameter
+          // light size is diameter
           disk_light.CreateRadiusAttr().Set(light->area_size / 2, timecode);
 
           // Coefficient approximated to follow Cycles results
@@ -63,7 +63,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
         }
         case LA_AREA_ELLIPSE: { /* An ellipse light will deteriorate into a disk light. */
           pxr::UsdLuxDiskLight disk_light = pxr::UsdLuxDiskLight::Define(stage, usd_path);
-          // average of light.size is diameter
+          // average of light size is diameter
           disk_light.CreateRadiusAttr().Set((light->area_size + light->area_sizey) / 4, timecode);
 
           // Coefficient approximated to follow Cycles results

--- a/source/blender/io/usd/intern/usd_writer_light.cc
+++ b/source/blender/io/usd/intern/usd_writer_light.cc
@@ -48,6 +48,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
       switch (light->area_shape) {
         case LA_AREA_DISK: {
           pxr::UsdLuxDiskLight disk_light = pxr::UsdLuxDiskLight::Define(stage, usd_path);
+          // light.size is diameter
           disk_light.CreateRadiusAttr().Set(light->area_size / 2, timecode);
 
           // Coefficient approximated to follow Cycles results
@@ -62,6 +63,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
         }
         case LA_AREA_ELLIPSE: { /* An ellipse light will deteriorate into a disk light. */
           pxr::UsdLuxDiskLight disk_light = pxr::UsdLuxDiskLight::Define(stage, usd_path);
+          // average of light.size is diameter
           disk_light.CreateRadiusAttr().Set((light->area_size + light->area_sizey) / 4, timecode);
 
           // Coefficient approximated to follow Cycles results


### PR DESCRIPTION
Fixed differences of light power between renderers;
added support for Spot light.

NOTE:
It is easier to test with https://github.com/bnagirniak/blender/pull/24