### PR TITLE
BLEN-239: Optimize update of USD stage if scene is updated

### DIFF
--- a/extern/usdhydra/addon/engine.py
+++ b/extern/usdhydra/addon/engine.py
@@ -8,6 +8,7 @@ import _usdhydra
 import MaterialX as mx
 
 from .usd_nodes import node_tree
+from .mx_nodes.node_tree import MxNodeTree
 from .utils import stages, logging
 log = logging.Log('engine')
 
@@ -28,6 +29,7 @@ class USDHydraEngine(bpy.types.RenderEngine):
 
     session = None
     delegate_name = "HdStormRendererPlugin"
+    materialx_data = []
 
     def __init__(self):
         self.session = None
@@ -61,9 +63,9 @@ class USDHydraEngine(bpy.types.RenderEngine):
 
         self.bl_use_gpu_context = self.delegate_name == "HdRprPlugin"
 
-        materialx_data = self.get_materialx_data(data, depsgraph)
+        self.get_materialx_data(data, depsgraph)
 
-        session_reset(self.session, data, bpy.context, depsgraph, materialx_data, is_blender_scene,
+        session_reset(self.session, data, bpy.context, depsgraph, self.materialx_data, is_blender_scene,
                       stage, self.delegate_name, self.is_preview)
         session_final_update(self.session, depsgraph)
 
@@ -101,9 +103,9 @@ class USDHydraEngine(bpy.types.RenderEngine):
             self.session = session_create(self)
 
         delegate_settings = self.sync_viewport_delegate_settings()
-        materialx_data = self.get_materialx_data(context, depsgraph)
+        self.get_materialx_data(context, depsgraph)
 
-        session_reset(self.session, data, context, depsgraph, materialx_data, is_blender_scene,
+        session_reset(self.session, data, context, depsgraph, self.materialx_data, is_blender_scene,
                       stage, self.delegate_name, self.is_preview)
         session_view_update(self.session, depsgraph, context, context.space_data, context.region_data, self.delegate_name, delegate_settings)
 
@@ -120,7 +122,33 @@ class USDHydraEngine(bpy.types.RenderEngine):
         return tuple()
 
     def get_materialx_data(self, context, depsgraph):
-        data = []
+
+        def update_materialx_data():
+            if not depsgraph.updates:
+                return
+
+            for mx_node_tree in (upd.id for upd in depsgraph.updates if isinstance(upd.id, MxNodeTree)):
+                for material in bpy.data.materials:
+                    if material.usdhydra.mx_node_tree and material.usdhydra.mx_node_tree.name == mx_node_tree.name:
+                        doc = material.usdhydra.export(None)
+                        if not doc:
+                            # log.warn("MX export failed", mat)
+                            continue
+
+                        matx_data = next((mat for mat in self.materialx_data if mat[0] == material.name), None)
+
+                        if not matx_data:
+                            mx_file = _usdhydra.utils.get_temp_file(".mtlx",
+                                                             f'{material.name}{material.usdhydra.mx_node_tree.name if material.usdhydra.mx_node_tree else ""}',
+                                                             False)
+
+                            mx.writeToXmlFile(doc, str(mx_file))
+                            surfacematerial = next((node for node in doc.getNodes()
+                                                    if node.getCategory() == 'surfacematerial'))
+                            self.materialx_data.append((material.name, str(mx_file), surfacematerial.getName()))
+                        else:
+                            mx.writeToXmlFile(doc, str(matx_data[1]))
+
         for obj in bpy.context.scene.objects:
             if obj.type in ('EMPTY', 'ARMATURE', 'LIGHT', 'CAMERA'):
                 continue
@@ -129,23 +157,23 @@ class USDHydraEngine(bpy.types.RenderEngine):
                 if not mat_slot:
                     continue
 
-                mat = mat_slot.material
+                material = mat_slot.material
+                matx_data = next((mat for mat in self.materialx_data if mat[0] == material.name), None)
 
-                mx_file = _usdhydra.utils.get_temp_file(".mtlx",
-                                                        f'{mat.name}{mat.usdhydra.mx_node_tree.name if mat.usdhydra.mx_node_tree else ""}',
-                                                        True)
+                if not matx_data:
+                    doc = material.usdhydra.export(obj)
+                    if not doc:
+                        # log.warn("MX export failed", mat)
+                        return None
+                    mx_file = _usdhydra.utils.get_temp_file(".mtlx",
+                                                            f'{material.name}{material.usdhydra.mx_node_tree.name if material.usdhydra.mx_node_tree else ""}',
+                                                            False)
+                    mx.writeToXmlFile(doc, str(mx_file))
+                    surfacematerial = next((node for node in doc.getNodes() if node.getCategory() == 'surfacematerial'))
 
-                doc = mat.usdhydra.export(obj)
-                if not doc:
-                    # log.warn("MX export failed", mat)
-                    return None
+                    self.materialx_data.append((material.name, str(mx_file), surfacematerial.getName()))
 
-                mx.writeToXmlFile(doc, str(mx_file))
-                surfacematerial = next((node for node in doc.getNodes() if node.getCategory() == 'surfacematerial'))
-
-                data.append((mat.name, str(mx_file), surfacematerial.getName()))
-
-        return tuple(data)
+        update_materialx_data()
 
 
 class USDHydraHdStormEngine(USDHydraEngine):

--- a/extern/usdhydra/session.h
+++ b/extern/usdhydra/session.h
@@ -39,7 +39,7 @@ public:
   ~BlenderSession();
 
   void create();
-  void reset(BL::Context b_context, Depsgraph *depsgraph, bool is_blender_scene, int stageId,
+  void reset(BL::Context b_context, PointerRNA depsgraphptr, bool is_blender_scene, int stageId,
              blender::io::usd::materialx_data_type materialx_data, const char *render_delegate, int is_preview);
   void render(BL::Depsgraph &b_depsgraph, const char *render_delegate, HdRenderSettingsMap delegate_settings);
   void render_gl(BL::Depsgraph &b_depsgraph, const char *render_delegate, HdRenderSettingsMap delegate_settings);
@@ -47,7 +47,8 @@ public:
   void view_update(BL::Depsgraph &b_depsgraph, BL::Context &b_context, const char *render_delegate, HdRenderSettingsMap delegate_settings);
   void sync(BL::Depsgraph &b_depsgraph, BL::Context &b_context);
   void sync_final_render(BL::Depsgraph &b_depsgraph);
-  UsdStageRefPtr export_scene_to_usd(BL::Context b_context, Depsgraph *depsgraph, blender::io::usd::materialx_data_type materialx_data, const char *render_delegate);
+  void export_scene_to_usd(BL::Context b_context, Depsgraph *depsgraph, blender::io::usd::materialx_data_type materialx_data,
+                           const char *render_delegate, set<SdfPath> existing_paths = {}, set<string> objects_to_update = {});
 
   template <typename T>
   float get_renderer_percent_done(T *renderer)

--- a/source/blender/io/usd/intern/usd_exporter_context.h
+++ b/source/blender/io/usd/intern/usd_exporter_context.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "usd.h"
-
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/common.h>
 

--- a/source/blender/io/usd/intern/usd_hierarchy_iterator.cc
+++ b/source/blender/io/usd/intern/usd_hierarchy_iterator.cc
@@ -33,11 +33,15 @@ USDHierarchyIterator::USDHierarchyIterator(Main *bmain,
                                            Depsgraph *depsgraph,
                                            pxr::UsdStageRefPtr stage,
                                            const USDExportParams &params,
-                                           materialx_data_type materialx_data)
+                                           materialx_data_type materialx_data,
+                                           std::set<pxr::SdfPath> existing_paths,
+                                           std::set<std::string> objects_to_update)
     : AbstractHierarchyIterator(bmain, depsgraph),
       stage_(stage),
       params_(params),
-      materialx_data_(materialx_data)
+      materialx_data_(materialx_data),
+      existing_paths_(existing_paths),
+      objects_to_update_(objects_to_update)
 {
 }
 
@@ -95,6 +99,18 @@ AbstractHierarchyWriter *USDHierarchyIterator::create_data_writer(const Hierarch
 {
   USDExporterContext usd_export_context = create_usd_export_context(context);
   USDAbstractWriter *data_writer = nullptr;
+
+  //if (params_.specified_objects_only) {
+  //  //if (objects_to_update_.count(context->object->id.name + 2) > 0) {
+  //  //  pxr::UsdPrim prim = stage_->GetPrimAtPath(pxr::SdfPath(context->higher_up_export_path));
+  //  //  prim.GetReferences().ClearReferences();
+  //  //  prim.SetActive(false);
+  //  //}
+  //  if (existing_paths_.count(usd_export_context.usd_path) > 0 && objects_to_update_.count(context->object->id.name + 2) == 0) {
+  //    delete data_writer;
+  //    return nullptr;
+  //  }
+  //}
 
   switch (context->object->type) {
     case OB_MESH:

--- a/source/blender/io/usd/intern/usd_hierarchy_iterator.h
+++ b/source/blender/io/usd/intern/usd_hierarchy_iterator.h
@@ -27,6 +27,8 @@ class USDHierarchyIterator : public AbstractHierarchyIterator {
   pxr::UsdTimeCode export_time_;
   const USDExportParams &params_;
   materialx_data_type materialx_data_;
+  std::set<pxr::SdfPath> existing_paths_;
+  std::set<std::string> objects_to_update_;
 
 
  public:
@@ -34,7 +36,9 @@ class USDHierarchyIterator : public AbstractHierarchyIterator {
                        Depsgraph *depsgraph,
                        pxr::UsdStageRefPtr stage,
                        const USDExportParams &params,
-                       materialx_data_type = materialx_data_type());
+                       materialx_data_type = materialx_data_type(),
+                       std::set<pxr::SdfPath> existing_paths = {},
+                       std::set<std::string> objects_to_update = {});
 
   void set_export_frame(float frame_nr);
   std::string get_export_file_path() const;

--- a/source/blender/io/usd/usd.h
+++ b/source/blender/io/usd/usd.h
@@ -37,6 +37,7 @@ struct USDExportParams {
   bool export_textures;
   bool overwrite_textures;
   bool relative_paths;
+  bool specified_objects_only;
 };
 
 struct USDImportParams {


### PR DESCRIPTION
- matx_data now writes only if there is a new material
- matx_data updated on depsgraph update and is written in the same mtlx file -> mtlx files no more unlimitedly generated in temp folder
- stage changed to in memory stage -> no more files in temp folder

Please also check error in console:
`Runtime Error: in _DefinePrim at line 3451 of D:\vasyl\AMD\blender-git\usd\USD\pxr\usd\usd\stage.cpp -- Failed to define UsdPrim </MaterialX>`
`Warning: in ReadMaterials at line 2156 of D:\vasyl\AMD\blender-git\usd\USD\pxr\usd\usdMtlx\reader.cpp -- Failed to create material 'Surfacematerial'`