### PR TITLE
BLEN-257: Make GL delegate to be disabled in USDHydra render settings

### DIFF
--- a/extern/usdhydra/CMakeLists.txt
+++ b/extern/usdhydra/CMakeLists.txt
@@ -77,6 +77,7 @@ set(ADDON_FILES
   addon/__init__.py
   addon/engine.py
   addon/handlers.py
+  addon/storm_engine.py
 )
 
 set(ADDON_USD_NODES_FILES

--- a/extern/usdhydra/addon/__init__.py
+++ b/extern/usdhydra/addon/__init__.py
@@ -19,29 +19,22 @@ bl_info = {
     "category": "Render"
 }
 
-# Support 'reload' case.
-if "bpy" in locals():
-    import importlib
-    importlib.reload(properties)
-    importlib.reload(engine)
-    importlib.reload(ui)
-    # importlib.reload(operators)
-
-else:
-    from . import (
-        properties,
-        engine,
-        usd_nodes,
-        ui,
-        handlers,
-    )
-
 import atexit
+
 import bpy
 from bpy.utils import register_class, unregister_class
-from .utils import logging
 
+from .utils import logging
 log = logging.Log('init')
+
+from . import (
+    properties,
+    engine,
+    usd_nodes,
+    ui,
+    handlers,
+    preferences,
+)
 
 
 def exit():
@@ -59,7 +52,7 @@ def register():
     usd_nodes.register()
     handlers.register()
 
-    register_class(engine.USDHydraHdStormEngine)
+    register_class(preferences.AddonPreferences)
 
     from .utils import enable_delegates
     enable_delegates()
@@ -73,4 +66,4 @@ def unregister():
     usd_nodes.unregister()
     handlers.unregister()
 
-    unregister_class(engine.USDHydraHdStormEngine)
+    unregister_class(preferences.AddonPreferences)

--- a/extern/usdhydra/addon/__init__.py
+++ b/extern/usdhydra/addon/__init__.py
@@ -23,6 +23,7 @@ import atexit
 
 import bpy
 from bpy.utils import register_class, unregister_class
+import _usdhydra
 
 from .utils import logging
 log = logging.Log('init')
@@ -56,6 +57,8 @@ def register():
 
     from .utils import enable_delegates
     enable_delegates()
+
+    _usdhydra.init()
 
 
 def unregister():

--- a/extern/usdhydra/addon/__init__.py
+++ b/extern/usdhydra/addon/__init__.py
@@ -49,6 +49,7 @@ def register():
     atexit.register(exit)
 
     register_class(preferences.AddonPreferences)
+    preferences.addon_preferences().init()
 
     properties.register()
     ui.register()

--- a/extern/usdhydra/addon/__init__.py
+++ b/extern/usdhydra/addon/__init__.py
@@ -35,6 +35,7 @@ from . import (
     ui,
     handlers,
     preferences,
+    storm_engine,
 )
 
 
@@ -47,13 +48,13 @@ def register():
     atexit.unregister(exit)
     atexit.register(exit)
 
-    properties.register()
+    register_class(preferences.AddonPreferences)
 
+    properties.register()
     ui.register()
     usd_nodes.register()
     handlers.register()
-
-    register_class(preferences.AddonPreferences)
+    storm_engine.register()
 
     from .utils import enable_delegates
     enable_delegates()
@@ -64,9 +65,11 @@ def register():
 def unregister():
     from .utils import disable_delegates
     disable_delegates()
+
     ui.unregister()
     properties.unregister()
     usd_nodes.unregister()
     handlers.unregister()
+    storm_engine.unregister()
 
     unregister_class(preferences.AddonPreferences)

--- a/extern/usdhydra/addon/__init__.py
+++ b/extern/usdhydra/addon/__init__.py
@@ -21,7 +21,6 @@ bl_info = {
 
 import atexit
 
-import bpy
 from bpy.utils import register_class, unregister_class
 import _usdhydra
 
@@ -57,14 +56,14 @@ def register():
     handlers.register()
     storm_engine.register()
 
-    from .utils import enable_delegates
+    from .engine import enable_delegates
     enable_delegates()
 
     _usdhydra.init()
 
 
 def unregister():
-    from .utils import disable_delegates
+    from .engine import disable_delegates
     disable_delegates()
 
     ui.unregister()

--- a/extern/usdhydra/addon/engine.py
+++ b/extern/usdhydra/addon/engine.py
@@ -7,7 +7,10 @@ import bpy
 import _usdhydra
 
 from .usd_nodes import node_tree
-from .utils import stages, logging
+from .utils import stages
+from .ui import panels
+
+from .utils import logging
 log = logging.Log('engine')
 
 
@@ -143,6 +146,16 @@ class USDHydraEngine(bpy.types.RenderEngine):
                     self.materialx_data.append((material.name, str(mx_file), surfacematerial.getName()))
 
         materialx.utils.update_materialx_data(depsgraph, self.materialx_data)
+
+    @classmethod
+    def register(cls):
+        log("Register", cls)
+        panels.register_engine(cls.bl_idname)
+
+    @classmethod
+    def unregister(cls):
+        log("Unregister", cls)
+        panels.unregister_engine(cls.bl_idname)
 
 
 def session_create(engine: USDHydraEngine):

--- a/extern/usdhydra/addon/engine.py
+++ b/extern/usdhydra/addon/engine.py
@@ -4,6 +4,7 @@
 # <pep8 compliant>
 
 import bpy
+import addon_utils
 import _usdhydra
 
 from .usd_nodes import node_tree
@@ -121,12 +122,12 @@ class USDHydraEngine(bpy.types.RenderEngine):
         return tuple()
 
     def get_materialx_data(self, context, depsgraph):
-        try:
-            import materialx
-
-        except Exception as e:
+        _, matx_enabled = addon_utils.check('materialx')
+        if not matx_enabled:
             log.warn("MaterialX Addon isn't loaded")
             return
+
+        import materialx
 
         for obj in bpy.context.scene.objects:
             if obj.type in ('EMPTY', 'ARMATURE', 'LIGHT', 'CAMERA'):

--- a/extern/usdhydra/addon/engine.py
+++ b/extern/usdhydra/addon/engine.py
@@ -25,9 +25,9 @@ class USDHydraEngine(bpy.types.RenderEngine):
     bl_use_shading_nodes_custom = False
 
     delegate_name = ""
+    session = None
 
     def __init__(self):
-        self.session = None
         self.materialx_data = []
 
     def __del__(self):

--- a/extern/usdhydra/addon/engine.py
+++ b/extern/usdhydra/addon/engine.py
@@ -3,8 +3,6 @@
 
 # <pep8 compliant>
 
-import sys
-
 import bpy
 import _usdhydra
 
@@ -18,21 +16,19 @@ def exit():
 
 
 class USDHydraEngine(bpy.types.RenderEngine):
-    bl_idname = 'USDHydra'
-    bl_label = "USD Hydra Internal"
-    bl_info = "USD Hydra rendering plugin"
+    bl_idname = ''
+    bl_label = ""
+    bl_info = ""
 
     bl_use_preview = True
     bl_use_shading_nodes = True
     bl_use_shading_nodes_custom = False
-    bl_use_gpu_context = True
 
-    session = None
-    delegate_name = "HdStormRendererPlugin"
-    materialx_data = []
+    delegate_name = ""
 
     def __init__(self):
         self.session = None
+        self.materialx_data = []
 
     def __del__(self):
         if not self.session:
@@ -147,19 +143,6 @@ class USDHydraEngine(bpy.types.RenderEngine):
                     self.materialx_data.append((material.name, str(mx_file), surfacematerial.getName()))
 
         materialx.utils.update_materialx_data(depsgraph, self.materialx_data)
-
-
-class USDHydraHdStormEngine(USDHydraEngine):
-    bl_idname = 'USDHydraHdStormRendererPlugin'
-    bl_label = "USD Hydra: GL"
-    bl_info = "USD Hydra HdStormRendererPlugin rendering plugin"
-
-    bl_use_preview = False
-    bl_use_shading_nodes = True
-    bl_use_shading_nodes_custom = False
-    bl_use_gpu_context = True
-
-    delegate_name = "HdStormRendererPlugin"
 
 
 def session_create(engine: USDHydraEngine):

--- a/extern/usdhydra/addon/preferences.py
+++ b/extern/usdhydra/addon/preferences.py
@@ -4,16 +4,13 @@
 # <pep8 compliant>
 
 import bpy
-from bpy.types import AddonPreferences, Operator
-from bpy.props import StringProperty, BoolProperty, EnumProperty
-
 import _usdhydra
 
-from ..utils import logging
+from .utils import logging
 log = logging.Log('preferences')
 
 
-class USDHYDRA_ADDON_PT_preferences(AddonPreferences):
+class AddonPreferences(bpy.types.AddonPreferences):
     bl_idname = "usdhydra"
 
     def init(self):
@@ -41,21 +38,12 @@ class USDHYDRA_ADDON_PT_preferences(AddonPreferences):
         _usdhydra.init()
         self.save()
 
-    # tmp_dir: StringProperty(
-    #     name="Temp Directory",
-    #     description="Set temp directory",
-    #     maxlen=1024,
-    #     subtype='DIR_PATH',
-    #     default=_usdhydra.utils.get_temp_dir(),
-    #     update=update_temp_dir,
-    # )
-
-    dev_tools: BoolProperty(
+    dev_tools: bpy.props.BoolProperty(
         name="Developer Tools",
         description="Enable developer tools",
         default=False,
     )
-    log_level: EnumProperty(
+    log_level: bpy.props.EnumProperty(
         name="Log Level",
         description="Select logging level",
         items=(('DEBUG', "Debug", "Log level DEBUG"),

--- a/extern/usdhydra/addon/preferences.py
+++ b/extern/usdhydra/addon/preferences.py
@@ -4,6 +4,7 @@
 # <pep8 compliant>
 
 import bpy
+from bpy.utils import register_class, unregister_class
 import _usdhydra
 
 from .utils import logging
@@ -18,6 +19,14 @@ class AddonPreferences(bpy.types.AddonPreferences):
 
     def update_log_level(self, context):
         logging.logger.setLevel(self.log_level)
+
+    def update_storm_delegate(self, context):
+        from .storm_engine import USDHydraHdStormEngine
+
+        if self.storm_delegate:
+            register_class(USDHydraHdStormEngine)
+        else:
+            unregister_class(USDHydraHdStormEngine)
 
     dev_tools: bpy.props.BoolProperty(
         name="Developer Tools",
@@ -39,21 +48,16 @@ class AddonPreferences(bpy.types.AddonPreferences):
         name="Storm Render Delegate",
         description="Enable Hydra Storm (OpenGL) render delegate",
         default=True,
+        update=update_storm_delegate,
     )
 
     def draw(self, context):
         layout = self.layout
-        layout.separator()
-        # layout.prop(self, "tmp_dir", icon='NONE' if Path(self.tmp_dir).exists() else 'ERROR')
-        layout.prop(self, "dev_tools")
-        layout.prop(self, "log_level")
-        layout.separator()
-
-
-
-        # row = col.row()
-        #row.operator("wm.url_open", text="Main Site", icon='URL').url = bl_info["main_web"]
-        #row.operator("wm.url_open", text="Community", icon='COMMUNITY').url = bl_info["community"]
+        box = layout.box()
+        box.prop(self, 'storm_delegate')
+        box = layout.box()
+        box.prop(self, 'dev_tools')
+        box.prop(self, 'log_level')
 
 
 def addon_preferences():

--- a/extern/usdhydra/addon/preferences.py
+++ b/extern/usdhydra/addon/preferences.py
@@ -5,7 +5,6 @@
 
 import bpy
 from bpy.utils import register_class, unregister_class
-import _usdhydra
 
 from .utils import logging
 log = logging.Log('preferences')
@@ -18,11 +17,13 @@ class AddonPreferences(bpy.types.AddonPreferences):
         self.update_log_level(None)
 
     def update_log_level(self, context):
+        log("update_log_level", self.log_level)
         logging.logger.setLevel(self.log_level)
 
     def update_storm_delegate(self, context):
         from .storm_engine import USDHydraHdStormEngine
 
+        log("update_storm_delegate", self.storm_delegate)
         if self.storm_delegate:
             register_class(USDHydraHdStormEngine)
         else:

--- a/extern/usdhydra/addon/preferences.py
+++ b/extern/usdhydra/addon/preferences.py
@@ -15,28 +15,9 @@ class AddonPreferences(bpy.types.AddonPreferences):
 
     def init(self):
         self.update_log_level(None)
-        self._init(None)
-
-    def save(self):
-        if hasattr(bpy.context, 'scene'):
-            bpy.ops.wm.save_userpref()
-
-    # def update_temp_dir(self, value):
-    #     if not Path(self.tmp_dir).exists() or tempfile.gettempdir() == str(Path(self.tmp_dir)):
-    #         log.info(f"Current temp directory is {tempfile.gettempdir()}")
-    #         return
-    #
-    #     tempfile.tempdir = Path(self.tmp_dir)
-    #     bpy.context.preferences.addons['usdhydra'].preferences['tmp_dir'] = str(_usdhydra.utils.get_temp_dir())
-    #     log.info(f"Current temp directory is changed to {bpy.context.preferences.addons['usdhydra'].preferences.tmp_dir}")
 
     def update_log_level(self, context):
         logging.logger.setLevel(self.log_level)
-        self.save()
-
-    def _init(self, context):
-        _usdhydra.init()
-        self.save()
 
     dev_tools: bpy.props.BoolProperty(
         name="Developer Tools",
@@ -54,6 +35,11 @@ class AddonPreferences(bpy.types.AddonPreferences):
         default='INFO',
         update=update_log_level,
     )
+    storm_delegate: bpy.props.BoolProperty(
+        name="Storm Render Delegate",
+        description="Enable Hydra Storm (OpenGL) render delegate",
+        default=True,
+    )
 
     def draw(self, context):
         layout = self.layout
@@ -63,10 +49,12 @@ class AddonPreferences(bpy.types.AddonPreferences):
         layout.prop(self, "log_level")
         layout.separator()
 
+
+
         # row = col.row()
         #row.operator("wm.url_open", text="Main Site", icon='URL').url = bl_info["main_web"]
         #row.operator("wm.url_open", text="Community", icon='COMMUNITY').url = bl_info["community"]
 
 
-def get_addon_pref():
+def addon_preferences():
     return bpy.context.preferences.addons['usdhydra'].preferences

--- a/extern/usdhydra/addon/properties/__init__.py
+++ b/extern/usdhydra/addon/properties/__init__.py
@@ -23,15 +23,13 @@ class USDHydraProperties(bpy.types.PropertyGroup):
 
 
 from . import (
-    preferences,
     scene,
     object,
     usd_stage,
     window_manager,
 )
-register_classes, unregister_classes = bpy.utils.register_classes_factory((
-    preferences.USDHYDRA_ADDON_PT_preferences,
 
+register_classes, unregister_classes = bpy.utils.register_classes_factory((
     scene.FinalRenderSettings,
     scene.ViewportRenderSettings,
     scene.SceneProperties,
@@ -47,9 +45,6 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory((
 
 def register():
     register_classes()
-
-    pref = preferences.get_addon_pref()
-    pref.init()
 
 
 def unregister():

--- a/extern/usdhydra/addon/storm_engine.py
+++ b/extern/usdhydra/addon/storm_engine.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2011-2022 Blender Foundation
+
+# <pep8 compliant>
+
+from .engine import USDHydraEngine
+
+
+class USDHydraHdStormEngine(USDHydraEngine):
+    bl_idname = 'USDHydraHdStormEngine'
+    bl_label = "USD Hydra: Storm"
+    bl_info = "USD Hydra Storm (OpenGL) render delegate"
+
+    bl_use_preview = False
+    bl_use_gpu_context = True
+
+    delegate_name = "HdStormRendererPlugin"

--- a/extern/usdhydra/addon/storm_engine.py
+++ b/extern/usdhydra/addon/storm_engine.py
@@ -3,6 +3,8 @@
 
 # <pep8 compliant>
 
+from bpy.utils import register_class, unregister_class
+
 from .engine import USDHydraEngine
 from .preferences import addon_preferences
 
@@ -19,8 +21,10 @@ class USDHydraHdStormEngine(USDHydraEngine):
 
 
 def register():
-    pass
+    if addon_preferences().storm_delegate:
+        register_class(USDHydraHdStormEngine)
 
 
 def unregister():
-    pass
+    if addon_preferences().storm_delegate:
+        unregister_class(USDHydraHdStormEngine)

--- a/extern/usdhydra/addon/storm_engine.py
+++ b/extern/usdhydra/addon/storm_engine.py
@@ -4,6 +4,7 @@
 # <pep8 compliant>
 
 from .engine import USDHydraEngine
+from .preferences import addon_preferences
 
 
 class USDHydraHdStormEngine(USDHydraEngine):
@@ -15,3 +16,11 @@ class USDHydraHdStormEngine(USDHydraEngine):
     bl_use_gpu_context = True
 
     delegate_name = "HdStormRendererPlugin"
+
+
+def register():
+    pass
+
+
+def unregister():
+    pass

--- a/extern/usdhydra/addon/ui/__init__.py
+++ b/extern/usdhydra/addon/ui/__init__.py
@@ -11,7 +11,8 @@ class USDHydra_Operator(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.engine in cls.COMPAT_ENGINES
+        return True
+        # return context.engine in cls.COMPAT_ENGINES
 
 
 class USDHydra_Panel(bpy.types.Panel):

--- a/extern/usdhydra/addon/ui/__init__.py
+++ b/extern/usdhydra/addon/ui/__init__.py
@@ -18,11 +18,12 @@ class USDHydra_Panel(bpy.types.Panel):
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
     bl_context = 'render'
-    COMPAT_ENGINES = {'USDHydraHdStormRendererPlugin'}
+    # COMPAT_ENGINES = {'USDHydraHdStormEngine'}
 
     @classmethod
     def poll(cls, context):
-        return context.engine in cls.COMPAT_ENGINES
+        return True
+        # return context.engine in cls.COMPAT_ENGINES
 
 
 class USDHydra_ChildPanel(bpy.types.Panel):
@@ -98,10 +99,8 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
 
 
 def register():
-    panels.register()
     register_classes()
 
 
 def unregister():
-    panels.unregister()
     unregister_classes()

--- a/extern/usdhydra/addon/ui/panels.py
+++ b/extern/usdhydra/addon/ui/panels.py
@@ -4,12 +4,10 @@
 # <pep8 compliant>
 
 import bpy
-#from .material import update_material_ui
 
 
 def get_panels():
     # follow the Cycles model of excluding panels we don't want
-
     exclude_panels = {
         'DATA_PT_area',
         'DATA_PT_context_light',
@@ -68,21 +66,20 @@ def get_panels():
         'EEVEE_MATERIAL_PT_settings',
     }
 
-    for panel in bpy.types.Panel.__subclasses__():
-        if hasattr(panel, 'COMPAT_ENGINES'):
-            if ('BLENDER_RENDER' in panel.COMPAT_ENGINES and panel.__name__ not in exclude_panels) \
-            or ('BLENDER_EEVEE' in panel.COMPAT_ENGINES and panel.__name__ in include_panels):
-                yield panel
+    for panel_cls in bpy.types.Panel.__subclasses__():
+        if hasattr(panel_cls, 'COMPAT_ENGINES') and (
+            ('BLENDER_RENDER' in panel_cls.COMPAT_ENGINES and panel_cls.__name__ not in exclude_panels) or
+            ('BLENDER_EEVEE' in panel_cls.COMPAT_ENGINES and panel_cls.__name__ in include_panels)
+        ):
+            yield panel_cls
 
 
-def register():
-    # set USDHydra panels filter
-    for panel in get_panels():
-        panel.COMPAT_ENGINES.add('USDHydraHdStormRendererPlugin')
+def register_engine(engine_id):
+    for panel_cls in get_panels():
+        panel_cls.COMPAT_ENGINES.add(engine_id)
 
 
-def unregister():
-    # remove USDHydra panels filter
-    for panel in get_panels():
-        if 'USDHydraHdStormRendererPlugin' in panel.COMPAT_ENGINES:
-            panel.COMPAT_ENGINES.remove('USDHydraHdStormRendererPlugin')
+def unregister_engine(engine_id):
+    for panel_cls in get_panels():
+        if engine_id in panel_cls.COMPAT_ENGINES:
+            panel_cls.COMPAT_ENGINES.remove(engine_id)

--- a/extern/usdhydra/addon/ui/usd_nodes.py
+++ b/extern/usdhydra/addon/ui/usd_nodes.py
@@ -110,8 +110,8 @@ class USDHYDRA_NODE_PT_usd_nodetree_dev(USDHydra_ChildPanel):
 
     @classmethod
     def poll(cls, context):
-        from preferences import get_addon_pref
-        return get_addon_pref().dev_tools
+        from preferences import addon_preferences
+        return addon_preferences().dev_tools
 
     def draw(self, context):
         layout = self.layout

--- a/extern/usdhydra/addon/ui/usd_nodes.py
+++ b/extern/usdhydra/addon/ui/usd_nodes.py
@@ -110,7 +110,7 @@ class USDHYDRA_NODE_PT_usd_nodetree_dev(USDHydra_ChildPanel):
 
     @classmethod
     def poll(cls, context):
-        from ..properties.preferences import get_addon_pref
+        from preferences import get_addon_pref
         return get_addon_pref().dev_tools
 
     def draw(self, context):

--- a/extern/usdhydra/addon/usd_nodes/node_tree.py
+++ b/extern/usdhydra/addon/usd_nodes/node_tree.py
@@ -28,9 +28,9 @@ class USDTree(bpy.types.ShaderNodeTree):
     _is_resetting = False
     _do_update = True
 
-    @classmethod
-    def poll(cls, context):
-        return context.engine in cls.COMPAT_ENGINES
+    # @classmethod
+    # def poll(cls, context):
+    #     return context.engine in cls.COMPAT_ENGINES
 
     @property
     def output_node(self):

--- a/extern/usdhydra/addon/utils/__init__.py
+++ b/extern/usdhydra/addon/utils/__init__.py
@@ -10,7 +10,6 @@ log = Log("utils")
 
 
 BLENDER_VERSION = f'{bpy.app.version[0]}.{bpy.app.version[1]}'
-RENDER_DELEGATE_ADDONS = set()
 
 
 def title_str(str):
@@ -39,62 +38,3 @@ def update_ui(area_type='PROPERTIES', region_type='WINDOW'):
                 for region in area.regions:
                     if region.type == region_type:
                         region.tag_redraw()
-
-
-def register_delegate(delegate_dir, engine_bl_idname):
-    import _usdhydra
-    from ..ui import USDHydra_Panel, USDHydra_Operator
-    from ..ui.panels import get_panels
-    from ..usd_nodes.node_tree import USDTree
-
-    global RENDER_DELEGATE_ADDONS
-
-    _usdhydra.init_delegate(str(delegate_dir))
-
-    for panel in get_panels():
-        panel.COMPAT_ENGINES.add(engine_bl_idname)
-
-    USDHydra_Panel.COMPAT_ENGINES.add(engine_bl_idname)
-    USDHydra_Operator.COMPAT_ENGINES.add(engine_bl_idname)
-    USDTree.COMPAT_ENGINES.add(engine_bl_idname)
-    RENDER_DELEGATE_ADDONS.add(engine_bl_idname)
-
-
-def unregister_delegate(engine_bl_idname):
-    from ..ui import USDHydra_Panel, USDHydra_Operator
-    from ..ui.panels import get_panels
-    from ..usd_nodes.node_tree import USDTree
-
-    try:
-        USDHydra_Panel.COMPAT_ENGINES.remove(engine_bl_idname)
-        USDHydra_Operator.COMPAT_ENGINES.remove(engine_bl_idname)
-
-        for panel in get_panels():
-            if 'USDHydraHdStormRendererPlugin' in panel.COMPAT_ENGINES:
-                panel.COMPAT_ENGINES.remove(engine_bl_idname)
-
-        USDTree.COMPAT_ENGINES.remove(engine_bl_idname)
-
-    except:
-        pass
-
-
-def disable_delegates():
-    import addon_utils
-    import bpy
-    for delegate in RENDER_DELEGATE_ADDONS:
-        enabled, loaded = addon_utils.check(delegate)
-        if enabled:
-            log.warn("Disable Delegate ", delegate)
-            addon_utils.disable(delegate)
-            bpy.ops.preferences.addon_disable(module=delegate)
-
-
-def enable_delegates():
-    import addon_utils, sys, importlib
-    for delegate in RENDER_DELEGATE_ADDONS:
-        enabled, loaded = addon_utils.check(delegate)
-        if not loaded or not loaded:
-            mod = sys.modules.get(delegate)
-            importlib.reload(mod)
-            addon_utils.enable(delegate)

--- a/extern/usdhydra/addon/utils/__init__.py
+++ b/extern/usdhydra/addon/utils/__init__.py
@@ -41,8 +41,6 @@ def update_ui(area_type='PROPERTIES', region_type='WINDOW'):
                         region.tag_redraw()
 
 
-
-
 def register_delegate(delegate_dir, engine_bl_idname):
     import _usdhydra
     from ..ui import USDHydra_Panel, USDHydra_Operator


### PR DESCRIPTION
## Technical steps
1. Made GL delegate to be disabled in USDHydra render settings.
2. Refactored code:
    - moved AddonPreferences -> addon/preferences.py
    - USDHydraHdStormEngine -> addon/storm_engine.py
    - register delegates code from utils to addon/engine.py
    - made code improvements and simplification

## Notes
This is first part of refactoring here. HdRPR delegate won't be working currently, it requires second part. 