### PR TITLE
BLEN-319: Shader editor isn't availabe for Hybrid render engines: Storm , RPR

### DIFF
--- a/extern/usdhydra/addon/engine.py
+++ b/extern/usdhydra/addon/engine.py
@@ -19,6 +19,7 @@ class HydraRenderEngine(bpy.types.RenderEngine):
     bl_info = ""
 
     bl_use_preview = True
+    bl_use_shading_nodes_custom = False
 
     delegate_id = ''
     engine_ptr = None


### PR DESCRIPTION
Added property `bl_use_shading_nodes_custom = False` for base RenderEngine